### PR TITLE
Replace react-inspector's TableInspector with a custom table inspector

### DIFF
--- a/data/AboutSyncTableInspector.js
+++ b/data/AboutSyncTableInspector.js
@@ -1,0 +1,160 @@
+let AboutSyncTableInspector = (function() {
+  'use strict';
+
+  const indexSymbol = Symbol('index');
+
+  function safeStringify(obj) {
+    try {
+      return JSON.stringify(obj);
+    } catch (e) {
+      return '<Recursive>';
+    }
+  }
+
+  function doSortBy(aVal, bVal) {
+    if ((aVal === undefined) !== (bVal === undefined)) {
+      // only one undefined
+      return (aVal === undefined ? 0 : 1) - (bVal === undefined ? 0 : 1);
+    }
+
+    if (!(isNaN(parseInt(aVal, 10)) || isNaN(parseInt(bVal, 10)))) {
+      return parseInt(aVal, 10) - parseInt(bVal, 10);
+    } else {
+      if (typeof(aVal) === 'object') {
+        aVal = safeStringify(aVal);
+      }
+      if (typeof(bVal) === 'object') {
+        bVal = safeStringify(bVal);
+      }
+      return aVal === bVal ? 0 : (aVal < bVal ? 1 : -1);
+    }
+  }
+
+  function defaultCellFormatter(cellValue, columnName, owningRow) {
+    let cellString = '';
+    let cellClass = `table-inspector-${typeof(cellValue)}-cell`
+    if (typeof(cellValue) !== 'undefined') {
+      cellString = safeStringify(cellValue);
+    }
+    return React.createElement('span',
+      {className: cellClass, title: cellString},
+      cellString);
+  }
+
+  class AboutSyncTableInspector extends React.Component {
+    constructor(props) {
+      super(props);
+      // default sort order is *ascending*, and the default sort key is the index.
+      this.state = {
+        sortBy: 0,
+        sortOrder: 1,
+        expandedRows: {}
+      };
+    }
+
+    expandRow(row) {
+      // This should be moved into the row itself, so that we don't rerender
+      // the whole table when this happens.
+      let rowIndex = row[indexSymbol];
+      this.state.expandedRows[rowIndex] = !this.state.expandedRows[rowIndex]
+      this.setState({
+        state: this.state.expandedRows
+      });
+    }
+
+    getColumns(data) {
+      let seenColumns = new Set();
+      for (let i = 0; i < data.length; ++i) {
+        let keys = Object.keys(data[i]);
+        for (let j = 0; j < keys.length; ++j) {
+          seenColumns.add(keys[j]);
+        }
+      }
+      // Convert values() iterator to array
+      return [...seenColumns.values()];
+    }
+
+    reorder(index) {
+      if (this.state.sortBy !== index) {
+        this.setState({ sortBy: index, sortOrder: 1 });
+      } else {
+        this.setState({ sortOrder: -this.state.sortOrder });
+      }
+    }
+
+    render() {
+      let {columns, data} = this.props;
+
+      if (!columns || !columns.length) {
+        columns = this.getColumns(data);
+      } else {
+        columns = columns.slice();
+      }
+
+      let rowData = data.map((item, index) =>
+        Object.assign({ [indexSymbol]: index }, item));
+
+      columns.unshift(indexSymbol);
+
+      rowData.sort((a, b) => {
+        let aVal = a[columns[this.state.sortBy]];
+        let bVal = b[columns[this.state.sortBy]];
+        return doSortBy(aVal, bVal) * this.state.sortOrder;
+      });
+
+      return React.createElement('table', { className: this.props.className },
+        React.createElement('thead', null,
+          React.createElement('tr', null,
+            columns.map((col, index) => {
+              let glyph = '';
+              if (this.state.sortBy === index) {
+                glyph = this.state.sortOrder < 0 ? ' ▼' : ' ▲';
+              }
+              // convert 'Symbol(index)' => '(index)'
+              let colName = typeof col === 'symbol' ? String(col).slice(6) : col;
+              return React.createElement('th', {
+                  key: String(col),
+                  onClick: () => this.reorder(index),
+                  style: { cursor: 'pointer' }
+                },
+                colName+glyph
+              );
+            })
+          )
+        ),
+        React.createElement('tbody', null,
+          rowData.map((row, index) =>
+            React.createElement('tr', {
+                key: row.id+':'+row[indexSymbol],
+                onDoubleClick: () => this.expandRow(row),
+                className: this.state.expandedRows[row[indexSymbol]] ? 'table-inspector-expanded-row' : '',
+              },
+              columns.map(colName =>
+                // Could also pass back 'original' row passed in with data[row[indexSymbol]],
+                // but it's not clear that that's worth doing, especially since then
+                // owningRow[columnName] wouldn't be reliable.
+                React.createElement('td', {key: String(colName)}, 
+                  this.props.cellFormatter(row[colName], colName, row)
+                )
+              )
+            )
+          )
+        )
+      );
+    }
+  }
+
+  AboutSyncTableInspector.propTypes = {
+    data: React.PropTypes.array.isRequired,
+    columns: React.PropTypes.array,
+    className: React.PropTypes.string,
+    cellFormatter: React.PropTypes.func,
+  };
+
+  AboutSyncTableInspector.defaultProps = {
+    cellFormatter: defaultCellFormatter,
+    className: 'table-inspector',
+  };
+
+  return AboutSyncTableInspector;
+}());

--- a/data/aboutsync.css
+++ b/data/aboutsync.css
@@ -111,3 +111,66 @@ html {
   border-bottom: 0;
   color: #333;
 }
+
+.table-inspector {
+  font-family: monospace;
+  line-height: 1;
+  border-spacing: 0;
+  border-collapse: collapse;
+  border: 1px solid #ddd;
+}
+
+.table-inspector th, .table-inspector td {
+  border: 1px solid #eee;
+  padding: 0.5em 1em;
+}
+
+.table-inspector thead tr,
+.table-inspector tbody tr:not(.table-inspector-expanded-row) td {
+  max-height: 3em;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  max-width: 10em;
+}
+
+.table-inspector .table-inspector-expanded-row {
+  outline: 1px solid #aaa;
+}
+
+.table-inspector th {
+  border-top: 0;
+}
+
+.table-inspector th:first-child,
+.table-inspector td:first-child {
+  border-left: 0;
+}
+.table-inspector th:last-child,
+.table-inspector td:last-child {
+  border-right: 0;
+}
+
+.table-inspector tbody tr:last-child {
+  border-bottom: 0;
+}
+
+.table-inspector thead {
+  font-weight: normal;
+}
+
+.table-inspector tbody tr:nth-of-type(2n+1) {
+  background-color: #eee;
+}
+
+.table-inspector-string-cell {
+  color: red;
+}
+
+.table-inspector-boolean-cell {
+  color: blue;
+}
+
+.table-inspector-number-cell {
+  color: green;
+}

--- a/data/components.js
+++ b/data/components.js
@@ -38,7 +38,7 @@ function createObjectInspector(name, data, expandLevel = 1) {
 }
 
 function createTableInspector(data) {
-  return React.createElement(ReactInspector.TableInspector, { data });
+  return React.createElement(AboutSyncTableInspector, { data });
 }
 
 // A placeholder for when we are still fetching data.

--- a/data/index.html
+++ b/data/index.html
@@ -8,6 +8,7 @@
     <script src="react-inspector/build/react-inspector.js"></script>
     <script src="react-treeview/build/react-treeview.js"></script>
     <script src="react-simpletabs/dist/react-simpletabs.js"></script>
+    <script src="AboutSyncTableInspector.js"></script>
   </head>
 
   <body>


### PR DESCRIPTION
Has a number of improved features listed in the commit message. Works like a drop-in replacement. It probably needs some CSS work though (it looks fine, but I didn't spend much time on the styling).

That said, I gave this some thinking and while this may be an improvement over the one we had before, what we probably want is something that will let us view the differences between two record lists (e.g. the list of remote items, and list of local items). Something like that could be built on top of this but I'm not sure something more custom wouldn't be better. (Although, being able to view just the record list on its own without any of this is probably still valuable).

Just a thought I had while working on the comparison code, since comparing lists of records is much simpler than comparing two trees, especially since at the end of the day, lists of records are what we actually have. (It's also probably more robust, since we can still compare a set of bookmarks where it's too messed up to successfully build a tree). 

It's also more general, given that most of the sync data is not tree structured afaik.