### PR TITLE
Improve table inspector performance, and show the items in the object…

### DIFF
--- a/data/aboutsync.css
+++ b/data/aboutsync.css
@@ -221,3 +221,10 @@ html {
 .table-inspector-number-cell {
   color: green;
 }
+
+.table-inspector .col-children,
+.table-inspector .col-parent {
+  /* Really the columns should be resizable, but these are the most
+     obvious places where that not working hurts */
+  min-width: 275px;
+}


### PR DESCRIPTION
… inspector in the expanded view.

I had been sitting on this for a while, and had been planning to add resizable columns to it before pushing, but the uninspectable "<Recursive>" is too annoying in the validation.