### PR TITLE
Fix handling of non-object records in table inspector, and ensure there's no flow content in "th"

### DIFF
--- a/data/aboutsync.css
+++ b/data/aboutsync.css
@@ -164,7 +164,7 @@ html {
 }
 
 .table-inspector th, .table-inspector td {
-  border: 1px solid #eee;
+  border: 1px solid #ccc;
   padding: 0.5em 1em;
   position: relative;
   overflow: hidden;
@@ -173,6 +173,7 @@ html {
 
 .table-inspector th .resizer {
   position: absolute;
+  display: block;
   right: 0;
   top: 0;
   bottom: 0;
@@ -187,7 +188,7 @@ html {
   cursor: ew-resize;
 }
 
-.table-inspector th span {
+.table-inspector th span:not(.resizer) {
   cursor: pointer;
 }
 
@@ -215,11 +216,11 @@ html {
   border-right: 0;
 }
 
-.table-inspector tbody tr:last-child {
+.table-inspector tr:last-child {
   border-bottom: 0;
 }
 
-.table-inspector tbody tr:nth-of-type(2n+1) {
+.table-inspector tr:nth-of-type(2n+1) {
   background-color: #eee;
 }
 


### PR DESCRIPTION
Fixes relating to the email you sent me last night.

We'd crash and be terribly broken if we gave AboutSyncTableInspector an array containing null or undefined. Now we handle this. To distinguish between e.g. an empty object and undefined/null, there's a new (record) column that contains the, err, actual record was passed in for this row.

Also, at least AFAICT we were breaking the rules by having a div in a th element, so I've changed it to a display:block span, and moved it to thead (this doesn't appear to matter, but it seems like it's worth doing).  I don't think this was the cause of the "findComponentRoot" issue, but I also can't 100% rule it out, and since it seems like it could potentially someday be an issue, why not do it now.

I've also tweaked the CSS to handle this last change, and I changed the cell border to a darker color because it looks really weird if you had an undefined record in the array (now that this works), since it would be a solid grey block (I think it was an accident that the background and border colors for the cells were the same anyway).