### PR TITLE
Show detected client cycles in the bookmark validator view

### DIFF
--- a/data/components.js
+++ b/data/components.js
@@ -476,6 +476,17 @@ const collectionComponentBuilders = {
         );
       }
 
+      if (probs.clientCycles && probs.clientCycles.length) {
+        for (let cycle of probs.clientCycles) {
+          let desc = React.createElement("p", null,
+            `Cycle detected through ${cycle.length} items on client`,
+            cycle.map((id, index) =>
+              describeId(`${index ? ":" : " =>"} {id}`)));
+          yield React.createElement("div", null, desc,
+            createTableInspector(cycle.map(id => serverMap.get(id))));
+        }
+      }
+
       yield describeProblemList(
         "The following server records have deleted parents not deleted but had a deleted parent.",
         probs.deletedParents, serverMap);


### PR DESCRIPTION
I had this locally while debugging the feature. (Worth noting that it won't show chris's bookmarks' client cycles, since our calls into places to follow the queries only will work if you actually have these as local bookmarks.)