### PR TITLE
Delete wrongParentName from bookmark validator view since that property no longer exists.

### DIFF
--- a/data/components.js
+++ b/data/components.js
@@ -489,10 +489,6 @@ const collectionComponentBuilders = {
         probs.parentNotFolder, serverMap);
 
       yield describeProblemList(
-        "The following server records had a parentName that did not match the parent's actual name.",
-        probs.wrongParentName, serverMap);
-
-      yield describeProblemList(
         "The following server records were not folders but contained children.",
         probs.childrenOnNonFolder, serverMap);
 


### PR DESCRIPTION
Might be jumping the gun ever so slightly here, but since I'm already messing with aboutsync I might as well delete this.

Worth noting that everything should still work without this patch, as we check that we actually got an array inside describeProblemList -- You could even argue that we *shouldn't* land this patch until more users will have the other patch, although since we don't actually care about this error it sounds like it would just confuse people.