### PR TITLE
Better handling of null records, fixes #26

### DIFF
--- a/data/aboutsync.css
+++ b/data/aboutsync.css
@@ -250,7 +250,7 @@ html {
   margin: 5px 0px;
 }
 
-.sql-error {
+.error-message {
   background: rgb(255, 128, 128);
   border: 1px solid red;
   margin: 5px;
@@ -259,7 +259,7 @@ html {
   position: relative;
 }
 
-.sql-error .close-error {
+.error-message .close-error {
   position: absolute;
   right: 5px;
   background: 0;
@@ -270,6 +270,6 @@ html {
   cursor: pointer;
 }
 
-.sql-error p {
+.error-message p {
   margin: 0;
 }

--- a/data/components.js
+++ b/data/components.js
@@ -352,7 +352,7 @@ class PlacesSqlView extends React.Component {
             "Execute SQL")
         ),
         this.state.error && (
-          div({ className: "sql-error" },
+          div({ className: "error-message" },
             button({ className: "close-error", onClick: e => this.closeError(), title: "Close" }, "X"),
             p(null, "Error running SQL: ", this.renderErrorMsg(this.state.error))
           )
@@ -754,12 +754,20 @@ class CollectionViewer extends React.Component {
       // Build up a set of tabs.
       let lastModified = new Date(this.props.info.lastModified);
       // "Summary" tab is first.
-      let numDeleted = this.state.records.filter(r => r.deleted).length;
-      let summary = React.createElement("div", null,
-                      React.createElement("p", { className: "collectionSummary" }, `${this.state.records.length} records (${numDeleted} deleted)`),
-                      React.createElement("span", { className: "collectionSummary" }, " last modified at "),
-                      React.createElement("span", { className: "collectionSummary" }, lastModified.toString())
-                    );
+      let numDeleted = this.state.records.filter(r => r && r.deleted).length;
+      let numNull = this.state.records.filter(r => !r).length;
+      let children = [
+        React.createElement("p", { className: "collectionSummary" }, `${this.state.records.length} records (${numDeleted} deleted)`),
+        React.createElement("span", { className: "collectionSummary" }, " last modified at "),
+        React.createElement("span", { className: "collectionSummary" }, lastModified.toString())
+      ];
+      if (numNull) {
+        children.push(
+          React.createElement("div", { className: "error-message" },
+            React.createElement("p", null,
+              `Collection contains ${numNull} null payloads!`)));
+      }
+      let summary = React.createElement("div", null, ...children);
 
       let tabs = [
         React.createElement(ReactSimpleTabs.Panel, { title: "Summary"}, summary),


### PR DESCRIPTION
Display an error in the collection summary if there are null records, and add the raw records (and their original data pre-decryption and deserialization) to the "Response" tab, since we weren't displaying that data anywhere.

Certainly the raw records are useful, but I'm willing to take out the predecryption/deserialization data if you are not okay with the WBORecord.prototype monkeypatch.

Related to [bug 1356581 on bugzilla](https://bugzil.la/1356581).