### PR TITLE
Use `getBatched` in Firefox 52+

### DIFF
--- a/data/provider.js
+++ b/data/provider.js
@@ -135,6 +135,10 @@ let Providers = (function() {
         }
         // Do the actual fetch after an event spin.
         this._collections[info.name] = Promise.resolve().then(() => {
+          if (typeof collection.getBatched == "function") {
+            // Firefox 52+ supports download batching.
+            return collection.getBatched();
+          }
           return collection.get();
         }).then(raw => {
           // turn it into a vanilla object.


### PR DESCRIPTION
The Python and Go servers behave differently when fetching records
without a limit: Python assumes "no limit" and returns everything,
while Go uses the default limit (1k). This meant the validator only
fetched a maximum of 1k records when talking to a Go server, and
reported all other records as "server missing".

In mozilla-services/go-syncstorage#166, @rfk suggested using download
batching instead of relying on the absence of a limit.