### PR TITLE
Add a FxA Devices tab to the client section

### DIFF
--- a/data/components.js
+++ b/data/components.js
@@ -431,6 +431,14 @@ const collectionComponentBuilders = {
     };
   },
 
+  async clients(provider, serverRecords) {
+    let fxaDevices = await fxAccounts.getDeviceList();
+    fxaDevices = JSON.parse(JSON.stringify(fxaDevices));
+    return {
+      "FxA Devices": createObjectInspector("Devices", fxaDevices)
+    }
+  },
+
   async passwords(provider, serverRecords) {
     Cu.import("resource://services-sync/engines/passwords.js");
     if (typeof PasswordValidator == "undefined") {


### PR DESCRIPTION
When people report devices list inconsistencies, I often ask them to copy the clients collection from about:sync and open the inspector on accounts.mozilla.com to copy the FxA devices list.
With this PR we can have both at the same place :)