### PR TITLE
Issue #19 - Register an nsIAboutModule for about:sync

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -1,6 +1,9 @@
 <!DOCTYPE html>
 <html>
   <head>
+    <meta charset="utf-8">
+    <base href="chrome://aboutsync/content/">
+    <title>About Sync</title>
     <link rel="stylesheet" type="text/css" href="aboutsync.css">
     <link rel="stylesheet" type="text/css" href="react-treeview/react-treeview.css">
     <script src="react-0.14.7/build/react.js"></script>


### PR DESCRIPTION
When doing some of the system addon work I came across pocket's [pages](https://searchfox.org/mozilla-central/source/browser/extensions/pocket/content/AboutPocket.jsm), which don't have in the AboutRedirector.cpp, so I based what it does on that more or less. It also doesn't seem to need an entry in the manifest either (although some documentation I found suggested that restartless addons can't/shouldn't put components there, so maybe this is expected).

I don't know if there are issues with doing it this way, but I haven't noticed any.