### PR TITLE
Fix about:sync being broken on nightly due to not loading our scripts.

### DIFF
--- a/data/index.html
+++ b/data/index.html
@@ -44,8 +44,8 @@
       </div>
       <div id="provider-info"></div>
     </div>
-    <script type="text/javascript;version=1.7" src="provider.js"></script>
-    <script type="text/javascript;version=1.7" src="components.js"></script>
-    <script type="text/javascript;version=1.7" src="config.js"></script>
+    <script src="provider.js"></script>
+    <script src="components.js"></script>
+    <script src="config.js"></script>
   </body>
 </html>


### PR DESCRIPTION
For whatever reason, `script type="text/javascript;version=1.7"` no longer loads (I think this is due to [bug 1428002](https://bugzil.la/1428002) landing, but that's a wild guess), which includes all the interesting parts of about:sync. We never needed this in the first place, so it's easiest to just take it out.

Without this patch, about:sync is completely broken.