### PR TITLE
Fix up data provider options

### DIFF
--- a/data/aboutsync.css
+++ b/data/aboutsync.css
@@ -94,6 +94,10 @@ html {
   margin-left: 5px;
 }
 
+.provider-extra label {
+  display: block;
+}
+
 .inline-id {
   border-bottom: 1px;
   border-bottom-color: green;


### PR DESCRIPTION
* For local sync data, the options are "limit history", "anonymize", and "export to file".
* For loading from a URL or file, the options are the URL input and file picker.

This commit groups the options with their matching providers, flattens `ProviderOptions` into `ProviderInfo` at the cost of some duplicated elements, and fixes a small typo that caused de-anonymized exporting to fail.