### PR TITLE
Allow client records edition

### DIFF
--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -236,7 +236,9 @@ class CollectionViewer extends React.Component {
   }
 
   renderTabs() {
-    let engine = Weave.Service.engineManager.get(this.props.info.name);
+    let engine = this.props.info.name == "clients" ?
+                 Weave.Service.clientsEngine :
+                 Weave.Service.engineManager.get(this.props.info.name);
     return (
       <TabView>
         <TabPanel name="Summary" key="summary">


### PR DESCRIPTION
The clients engine is never registered in the engine manager for Reasons, so we need to special case it to allow client records edition to work.