### PR TITLE
Compatibility fixes for Waterfox and ESR

### DIFF
--- a/bootstrap.js
+++ b/bootstrap.js
@@ -8,6 +8,11 @@ const WeaveConstants = Cu.import("resource://services-sync/constants.js", {});
 Cu.import("resource://gre/modules/Log.jsm");
 Cu.import("resource://services-sync/main.js");
 
+if (typeof console !== "object") {
+  XPCOMUtils.defineLazyModuleGetter(this, "console",
+                                    "resource://gre/modules/Console.jsm");
+}
+
 XPCOMUtils.defineLazyServiceGetter(this, "AlertsService", "@mozilla.org/alerts-service;1", "nsIAlertsService");
 
 // data: URIs we use with the nsIProcessScriptLoader to register "about:sync"
@@ -193,7 +198,7 @@ function startup(data, reason) {
 
   // for some reason we can't use chrome://aboutsync at the top-level of
   // this module, but only after startup is called.
-  const { Config } = ChromeUtils.import("chrome://aboutsync/content/config.js");
+  const { Config } = Cu.import("chrome://aboutsync/content/config.js", {});
   Config.initialize();
 }
 
@@ -229,7 +234,7 @@ function shutdown(data, reason) {
     Services.obs.removeObserver(syncStatusObserver, topic);
   }
 
-  const { Config } = Cu.import("chrome://aboutsync/content/config.js");
+  const { Config } = Cu.import("chrome://aboutsync/content/config.js", {});
   Config.finalize();
   // And unload it, so changes will get picked up if we reload the addon.
   Cu.unload("chrome://aboutsync/content/config.js");

--- a/data/config.js
+++ b/data/config.js
@@ -138,7 +138,14 @@ function initialize() {
 }
 
 function finalize() {
-  Services.obs.removeObserver(startoverObserver, "weave:service:start-over:finish");
+  let observers = Services.obs.enumerateObservers("weave:service:start-over:finish");
+  while (observers.hasMoreElements()) {
+    let observer = observers.getNext();
+    if (observer == startoverObserver) {
+      Services.obs.removeObserver(observer, "weave:service:start-over:finish");
+      break;
+    }
+  }
 }
 
 

--- a/data/config.js
+++ b/data/config.js
@@ -5,8 +5,16 @@
 // This is a bit of a special module in that it's imported both by bootstrap.js
 // and by the react-based UI code, and we also want it to be a singleton.
 
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+
 const { Services } = Cu.import("resource://gre/modules/Services.jsm", {});
 const { Preferences } = Cu.import("resource://gre/modules/Preferences.jsm", {});
+const { XPCOMUtils } = Cu.import("resource://gre/modules/XPCOMUtils.jsm", {});
+
+if (typeof console !== "object") {
+  XPCOMUtils.defineLazyModuleGetter(this, "console",
+                                    "resource://gre/modules/Console.jsm");
+}
 
 function fixDesc(desc) {
   return desc.replace(/( |\t|\r|\n)+/g, " ");

--- a/src/CollectionsViewer.jsx
+++ b/src/CollectionsViewer.jsx
@@ -93,8 +93,8 @@ const collectionComponentBuilders = {
 
   async clients(provider, serverRecords) {
     const fxAccounts = importLocal("resource://gre/modules/FxAccounts.jsm").fxAccounts;
-    let fxaDevices = await fxAccounts.getDeviceList();
-    fxaDevices = JSON.parse(JSON.stringify(fxaDevices));
+    let fxaDevices = typeof fxAccounts.getDeviceList == "function" ?
+                     Cu.cloneInto(await fxAccounts.getDeviceList(), {}) : [];
     return {
       "FxA Devices": <ObjectInspector name="Devices" data={fxaDevices} expandLevel={1}/>
     };


### PR DESCRIPTION
I tested this out on Firefox ESR 52. A few things have changed since 52, which prevented About Sync from working:

* `ChromeUtils.import` was added in [Firefox 59](https://bugzilla.mozilla.org/show_bug.cgi?id=1431057).
* `console` was exposed to `System` in [Firefox 59](https://bugzilla.mozilla.org/show_bug.cgi?id=1425463).
* Global `C*` aliases were added in [Firefox 60](https://bugzilla.mozilla.org/show_bug.cgi?id=767640).
* `fxAccounts.getDevices` was added in [Firefox 55](https://bugzilla.mozilla.org/show_bug.cgi?id=1339861).

I also fixed a harmless, but annoying error that we'd log to the Browser Console if we called `Config.finalize()` before `initialize()`, and tried to remove the config observer before it was added...but I'm happy to drop this commit if it's not necessary.