### PR TITLE
Add an option to enable Browser Console logging

### DIFF
--- a/src/config.jsx
+++ b/src/config.jsx
@@ -130,6 +130,9 @@ class LoggingConfig extends React.Component {
         <LogLevelComponent label="Level of messages written to about:sync-logs log files"
                            prefs={["services.sync.log.appender.file.level"]}/>
 
+        <LogLevelComponent label="Level of messages written to the Browser Console - useful for live debugging, when a log file isn't always flushed"
+                           prefs={["services.sync.log.appender.console"]}/>
+
         <LogLevelComponent label="Level of messages written to dump - useful primarily for developers"
                            prefs={["services.sync.log.appender.dump"]}/>
 


### PR DESCRIPTION
In [bug 1617503](https://bugzilla.mozilla.org/show_bug.cgi?id=1617503#c13), a user was having issues with a wedged Places
connection. I was curious if that was caused by a stuck merge runnable,
so I asked the user to enable trace logging. However, Desktop doesn't
flush log files to disk (via `resetFileLog`) until the sync finishes
or there's an error—see `policies.js` for those cases. This means
log files aren't always helpful for seeing stuck syncs.

We do provide an option for `dump` logging, but that requires
launching Firefox from the command line, which is tricky if you're
not used to doing that, and also includes lots of other warnings and
log output. The Browser Console is much easier to access, and also
gives us live logs. We already have a pref controlling that, and this
patch just surfaces it in the UI.